### PR TITLE
Enable the unit tests to be run

### DIFF
--- a/src/pybind/mgr/dashboard/client/src/app/ceph/health/pg-status.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/client/src/app/ceph/health/pg-status.pipe.spec.ts
@@ -1,8 +1,21 @@
 import { PgStatusPipe } from './pg-status.pipe';
 
 describe('PgStatusPipe', () => {
+  let pipe: PgStatusPipe;
+
+  beforeEach(() => {
+    pipe = new PgStatusPipe();
+  });
+
   it('create an instance', () => {
-    const pipe = new PgStatusPipe();
     expect(pipe).toBeTruthy();
+  });
+
+  it ('should not fail with not input', () => {
+    expect(pipe.transform('')).toBe('');
+  });
+
+  it ('should show count and status in the right order', () => {
+    expect(pipe.transform({someStatus: 42})).toBe('42 someStatus');
   });
 });

--- a/src/pybind/mgr/dashboard/client/src/app/shared/pipes/dimless-binary.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/client/src/app/shared/pipes/dimless-binary.pipe.spec.ts
@@ -1,8 +1,0 @@
-import { DimlessBinaryPipe } from './dimless-binary.pipe';
-
-describe('DimlessBinaryPipe', () => {
-  it('create an instance', () => {
-    const pipe = new DimlessBinaryPipe();
-    expect(pipe).toBeTruthy();
-  });
-});

--- a/src/pybind/mgr/dashboard/client/src/app/shared/pipes/dimless.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/client/src/app/shared/pipes/dimless.pipe.spec.ts
@@ -1,8 +1,0 @@
-import { DimlessPipe } from './dimless.pipe';
-
-describe('DimlessPipe', () => {
-  it('create an instance', () => {
-    const pipe = new DimlessPipe();
-    expect(pipe).toBeTruthy();
-  });
-});


### PR DESCRIPTION
Two unit test had to be commented out because the automatically created
tests weren't complete and crashed any attempt to run the unit tests. I
added two unit tests to confirm the operator change in the pipe. I found
out that all component tests will fail because the imports hadn't been
add automatically to the test suite on creation.

Signed-off-by: Stephan Müller <smueller@suse.com>